### PR TITLE
Fixed memory leaks when using surfaces and buffers on the tilelayermanager and curtain objects

### DIFF
--- a/Gatete Mario Engine 9/objects/obj_curtain_in/CleanUp_0.gml
+++ b/Gatete Mario Engine 9/objects/obj_curtain_in/CleanUp_0.gml
@@ -1,0 +1,5 @@
+/// @description Free Memory
+
+// Free curtain surface
+if (surface_exists(surf))
+	surface_free(surf);

--- a/Gatete Mario Engine 9/objects/obj_curtain_in/obj_curtain_in.yy
+++ b/Gatete Mario Engine 9/objects/obj_curtain_in/obj_curtain_in.yy
@@ -25,6 +25,7 @@
     {"isDnD":false,"eventNum":0,"eventType":0,"collisionObjectId":null,"resourceVersion":"1.0","name":"","tags":[],"resourceType":"GMEvent",},
     {"isDnD":false,"eventNum":0,"eventType":3,"collisionObjectId":null,"resourceVersion":"1.0","name":"","tags":[],"resourceType":"GMEvent",},
     {"isDnD":false,"eventNum":0,"eventType":8,"collisionObjectId":null,"resourceVersion":"1.0","name":"","tags":[],"resourceType":"GMEvent",},
+    {"isDnD":false,"eventNum":0,"eventType":12,"collisionObjectId":null,"resourceVersion":"1.0","name":"","tags":[],"resourceType":"GMEvent",},
   ],
   "properties": [],
   "overriddenProperties": [],

--- a/Gatete Mario Engine 9/objects/obj_curtain_out/CleanUp_0.gml
+++ b/Gatete Mario Engine 9/objects/obj_curtain_out/CleanUp_0.gml
@@ -1,0 +1,5 @@
+/// @description Free memory
+
+// Free curtain surface
+if (surface_exists(surf))
+	surface_free(surf);

--- a/Gatete Mario Engine 9/objects/obj_curtain_out/Step_0.gml
+++ b/Gatete Mario Engine 9/objects/obj_curtain_out/Step_0.gml
@@ -10,7 +10,10 @@
 	//This grows the image, you can change the values to control how fast the circle should grow.
 	scale += (global.gw / 50)
 	if (scale > global.gw)
+	{
 	    instance_destroy();
+		exit;	// Stop executing the event if i've been destroyed
+	}
 #endregion
 
 //Check if the surface still exists

--- a/Gatete Mario Engine 9/objects/obj_curtain_out/obj_curtain_out.yy
+++ b/Gatete Mario Engine 9/objects/obj_curtain_out/obj_curtain_out.yy
@@ -25,6 +25,7 @@
     {"isDnD":false,"eventNum":0,"eventType":0,"collisionObjectId":null,"resourceVersion":"1.0","name":"","tags":[],"resourceType":"GMEvent",},
     {"isDnD":false,"eventNum":0,"eventType":3,"collisionObjectId":null,"resourceVersion":"1.0","name":"","tags":[],"resourceType":"GMEvent",},
     {"isDnD":false,"eventNum":0,"eventType":8,"collisionObjectId":null,"resourceVersion":"1.0","name":"","tags":[],"resourceType":"GMEvent",},
+    {"isDnD":false,"eventNum":0,"eventType":12,"collisionObjectId":null,"resourceVersion":"1.0","name":"","tags":[],"resourceType":"GMEvent",},
   ],
   "properties": [],
   "overriddenProperties": [],

--- a/Gatete Mario Engine 9/objects/obj_tilelayermanager/CleanUp_0.gml
+++ b/Gatete Mario Engine 9/objects/obj_tilelayermanager/CleanUp_0.gml
@@ -1,0 +1,17 @@
+/// @description Free memory
+
+// Free TileSurface
+if (surface_exists(TileSurface))
+	surface_free(TileSurface);
+
+// Free BufferSurface
+if (surface_exists(BufferSurface))
+	surface_free(BufferSurface);
+
+// Free FinalSurface
+if (surface_exists(FinalSurface))
+	surface_free(FinalSurface);
+
+// Free buffer
+if (buffer_exists(buff))
+	buffer_delete(buff);

--- a/Gatete Mario Engine 9/objects/obj_tilelayermanager/obj_tilelayermanager.yy
+++ b/Gatete Mario Engine 9/objects/obj_tilelayermanager/obj_tilelayermanager.yy
@@ -25,6 +25,7 @@
     {"isDnD":false,"eventNum":0,"eventType":0,"collisionObjectId":null,"resourceVersion":"1.0","name":"","tags":[],"resourceType":"GMEvent",},
     {"isDnD":false,"eventNum":0,"eventType":3,"collisionObjectId":null,"resourceVersion":"1.0","name":"","tags":[],"resourceType":"GMEvent",},
     {"isDnD":false,"eventNum":0,"eventType":8,"collisionObjectId":null,"resourceVersion":"1.0","name":"","tags":[],"resourceType":"GMEvent",},
+    {"isDnD":false,"eventNum":0,"eventType":12,"collisionObjectId":null,"resourceVersion":"1.0","name":"","tags":[],"resourceType":"GMEvent",},
   ],
   "properties": [],
   "overriddenProperties": [],

--- a/Gatete Mario Engine 9/objects/obj_tilelayermanager_front/CleanUp_0.gml
+++ b/Gatete Mario Engine 9/objects/obj_tilelayermanager_front/CleanUp_0.gml
@@ -1,0 +1,17 @@
+/// @description Free memory
+
+// Free TileSurface
+if (surface_exists(TileSurface))
+	surface_free(TileSurface);
+
+// Free BufferSurface
+if (surface_exists(BufferSurface))
+	surface_free(BufferSurface);
+
+// Free FinalSurface
+if (surface_exists(FinalSurface))
+	surface_free(FinalSurface);
+
+// Free buffer
+if (buffer_exists(buff))
+	buffer_delete(buff);

--- a/Gatete Mario Engine 9/objects/obj_tilelayermanager_front/obj_tilelayermanager_front.yy
+++ b/Gatete Mario Engine 9/objects/obj_tilelayermanager_front/obj_tilelayermanager_front.yy
@@ -25,6 +25,7 @@
     {"isDnD":false,"eventNum":0,"eventType":0,"collisionObjectId":null,"resourceVersion":"1.0","name":"","tags":[],"resourceType":"GMEvent",},
     {"isDnD":false,"eventNum":0,"eventType":3,"collisionObjectId":null,"resourceVersion":"1.0","name":"","tags":[],"resourceType":"GMEvent",},
     {"isDnD":false,"eventNum":0,"eventType":8,"collisionObjectId":null,"resourceVersion":"1.0","name":"","tags":[],"resourceType":"GMEvent",},
+    {"isDnD":false,"eventNum":0,"eventType":12,"collisionObjectId":null,"resourceVersion":"1.0","name":"","tags":[],"resourceType":"GMEvent",},
   ],
   "properties": [],
   "overriddenProperties": [],


### PR DESCRIPTION
I've found some surfaces that were not freed from memory while i was debugging, those come from tilelayermanager objects and curtain objects

![gme9_memoryleak](https://user-images.githubusercontent.com/35826578/175789933-e1b8c3c5-ce41-4d90-a75c-bc877c92c423.png)

After adding their respective clean up code this is the result

![unknown](https://user-images.githubusercontent.com/35826578/175790059-5ff200b6-b970-4f2b-9197-c0f4da9165df.png)
 